### PR TITLE
fix race condition

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -16,13 +16,14 @@ do
         esac
 done
 
+#Initialize log directory.
+mkdir -p logs/nginx
+touch logs/nginx/access.log logs/nginx/error.log
+echo 'buildpack=nginx at=logs-initialized'
+
 #Start log redirection.
 (
-	#Initialize log directory.
-	mkdir -p logs/nginx
-	touch logs/nginx/access.log logs/nginx/error.log
 	#Redirect NGINX logs to stdout.
-	echo 'buildpack=nginx at=logs-initialized'
 	tail -qF -n 0 logs/nginx/*.log
 	echo 'logs' >$psmgr
 ) &


### PR DESCRIPTION
Finally got around to fixing r101-marketing and r101-dashboard heroku errors.
This happens when the nginx buildpack starts, such as at deploys and every day.
I have not tested any of this code, but it looks right to me.
